### PR TITLE
add reference

### DIFF
--- a/contracts/TokenRequest.sol
+++ b/contracts/TokenRequest.sol
@@ -57,7 +57,7 @@ contract TokenRequest is AragonApp {
     event SetVault(address vault);
     event TokenAdded(address indexed token);
     event TokenRemoved(address indexed token);
-    event TokenRequestCreated(uint256 requestId, address requesterAddress, address depositToken, uint256 depositAmount, uint256 requestAmount);
+    event TokenRequestCreated(uint256 requestId, address requesterAddress, address depositToken, uint256 depositAmount, uint256 requestAmount, string reference);
     event TokenRequestRefunded(uint256 requestId, address refundToAddress, address refundToken, uint256 refundAmount);
     event TokenRequestFinalised(uint256 requestId, address requester, address depositToken, uint256 depositAmount, uint256 requestAmount);
 
@@ -134,8 +134,9 @@ contract TokenRequest is AragonApp {
     * @param _depositToken Address of the token being deposited
     * @param _depositAmount Amount of the token being deposited
     * @param _requestAmount Amount of the token being requested
+    * @param _reference String detailing request reason
     */
-    function createTokenRequest(address _depositToken, uint256 _depositAmount, uint256 _requestAmount)
+    function createTokenRequest(address _depositToken, uint256 _depositAmount, uint256 _requestAmount, string _reference)
     external
     payable
     returns (uint256)
@@ -155,7 +156,7 @@ contract TokenRequest is AragonApp {
         tokenRequests[tokenRequestId] = TokenRequest(msg.sender, _depositToken, _depositAmount, _requestAmount);
         addressesTokenRequestIds[msg.sender].push(tokenRequestId);
 
-        emit TokenRequestCreated(tokenRequestId, msg.sender, _depositToken, _depositAmount, _requestAmount);
+        emit TokenRequestCreated(tokenRequestId, msg.sender, _depositToken, _depositAmount, _requestAmount, _reference);
 
         return tokenRequestId;
     }

--- a/test/TokenRequestTest.js
+++ b/test/TokenRequestTest.js
@@ -24,6 +24,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
   const ROOT_TOKEN_AMOUNT = 100
   const MOCK_TOKEN_BALANCE = 100000
   const getBalance = getBalanceFn(web3)
+  const REFERENCE = 'This is a token request test.'
 
   before('deploy base apps', async () => {
     tokenRequestBase = await TokenRequest.new()
@@ -258,12 +259,12 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
       })
     })
 
-    describe('createTokenRequest(address _depositToken, uint256 _depositAmount, uint256 _requestAmount)', () => {
+    describe('createTokenRequest(address _depositToken, uint256 _depositAmount, uint256 _requestAmount, string _reference)', () => {
       it('creates a new token request in exchange for Ether', async () => {
         const expectedEtherBalance = 2000
         const expectedNextTokenRequestId = 1
 
-        await tokenRequest.createTokenRequest(ETH_ADDRESS, ROOT_ETHER_AMOUNT, 1, {
+        await tokenRequest.createTokenRequest(ETH_ADDRESS, ROOT_ETHER_AMOUNT, 1, REFERENCE, {
           value: ROOT_ETHER_AMOUNT,
         })
 
@@ -276,7 +277,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
 
       it('should not create a new request with different _depositAmount and value', async () => {
         await assertRevert(
-          tokenRequest.createTokenRequest(ETH_ADDRESS, 100, 1, {
+          tokenRequest.createTokenRequest(ETH_ADDRESS, 100, 1, REFERENCE, {
             value: 50,
           }),
           'TOKEN_REQUEST_ETH_VALUE_MISMATCH'
@@ -291,7 +292,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
           from: rootAccount,
         })
 
-        await tokenRequest.createTokenRequest(mockErc20.address, ROOT_TOKEN_AMOUNT, 300)
+        await tokenRequest.createTokenRequest(mockErc20.address, ROOT_TOKEN_AMOUNT, 300, REFERENCE)
 
         const actualTokenRequestBalance = await mockErc20.balanceOf(tokenRequest.address)
 
@@ -303,7 +304,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
 
       it('should not create a new request without token approve', async () => {
         await assertRevert(
-          tokenRequest.createTokenRequest(mockErc20.address, 100, 1),
+          tokenRequest.createTokenRequest(mockErc20.address, 100, 1, REFERENCE),
           'TOKEN_REQUEST_TOKEN_TRANSFER_REVERTED'
         )
       })
@@ -342,9 +343,15 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         await mockErc20.approve(tokenRequest.address, ROOT_TOKEN_AMOUNT, {
           from: rootAccount,
         })
-        await tokenRequest.createTokenRequest(mockErc20.address, expectedVaultBalance, expectedUserMiniMeBalance, {
-          from: rootAccount,
-        })
+        await tokenRequest.createTokenRequest(
+          mockErc20.address,
+          expectedVaultBalance,
+          expectedUserMiniMeBalance,
+          REFERENCE,
+          {
+            from: rootAccount,
+          }
+        )
 
         await forwarderMock.forward(script, { from: rootAccount })
 
@@ -359,7 +366,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         const expectedUserMiniMeBalance = 300
         const expectedVaultBalance = 200
 
-        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, {
+        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, REFERENCE, {
           from: rootAccount,
           value: expectedVaultBalance,
         })
@@ -377,7 +384,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         const expectedUserMiniMeBalance = 300
         const expectedVaultBalance = 0
 
-        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, {
+        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, REFERENCE, {
           from: rootAccount,
           value: expectedVaultBalance,
         })
@@ -395,12 +402,12 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         const expectedUserMiniMeBalance = 300
         const expectedVaultBalance = 200
 
-        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, {
+        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, REFERENCE, {
           from: rootAccount,
           value: expectedVaultBalance,
         })
 
-        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, {
+        await tokenRequest.createTokenRequest(ETH_ADDRESS, expectedVaultBalance, expectedUserMiniMeBalance, REFERENCE, {
           from: rootAccount,
           value: expectedVaultBalance,
         })
@@ -420,7 +427,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         await mockErc20.approve(tokenRequest.address, refundAmount, {
           from: rootAccount,
         })
-        await tokenRequest.createTokenRequest(mockErc20.address, refundAmount, 1, {
+        await tokenRequest.createTokenRequest(mockErc20.address, refundAmount, 1, REFERENCE, {
           from: rootAccount,
         })
 
@@ -434,7 +441,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         const weiValue = 3000000000000000
         const expectedETHBalance = await web3.eth.getBalance(refundEthAccount)
 
-        const request = await tokenRequest.createTokenRequest(ETH_ADDRESS, weiValue, 1, {
+        const request = await tokenRequest.createTokenRequest(ETH_ADDRESS, weiValue, 1, REFERENCE, {
           value: weiValue,
           from: refundEthAccount,
         })
@@ -461,7 +468,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         const zeroWei = 0
         const expectedETHBalance = await web3.eth.getBalance(refundEthAccount)
 
-        const request = await tokenRequest.createTokenRequest(ETH_ADDRESS, zeroWei, 1, {
+        const request = await tokenRequest.createTokenRequest(ETH_ADDRESS, zeroWei, 1, REFERENCE, {
           value: zeroWei,
           from: refundEthAccount,
         })
@@ -488,7 +495,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
         await mockErc20.approve(tokenRequest.address, ROOT_TOKEN_AMOUNT, {
           from: rootAccount,
         })
-        await tokenRequest.createTokenRequest(mockErc20.address, ROOT_TOKEN_AMOUNT, 1, {
+        await tokenRequest.createTokenRequest(mockErc20.address, ROOT_TOKEN_AMOUNT, 1, REFERENCE, {
           from: rootAccount,
         })
 
@@ -497,7 +504,7 @@ contract('TokenRequest', ([rootAccount, ...accounts]) => {
 
       it('should not refund the same request twice', async () => {
         const weiValue = 1000000000000000
-        await tokenRequest.createTokenRequest(ETH_ADDRESS, weiValue, 1, {
+        await tokenRequest.createTokenRequest(ETH_ADDRESS, weiValue, 1, REFERENCE, {
           value: weiValue,
           from: refundEthAccount,
         })


### PR DESCRIPTION
This PR includes the Reference string for a token request, we don't need to store it as we can just emit once the request is created and read if from the frontend 

This closes #83 