### PR TITLE
Update apm staging registry

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -33,8 +33,8 @@
       "network": "rinkeby"
     },
     "staging": {
-      "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
-      "appName": "token-request-staging.open.aragonpm.eth",
+      "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
+      "appName": "token-request.open.aragonpm.eth",
       "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
       "network": "rinkeby"
     },


### PR DESCRIPTION
APM Staging registry has been updated so we can use it now instead of using the traditional rinkeby apm repo with the staging tag on the package name