### PR TITLE
Update rinkeby and mainnet appNames

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -26,21 +26,21 @@
       "network": "development",
       "appName": "token-request.open.aragonpm.eth"
     },
-    "rinkeby": {
-      "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
-      "appName": "token-request.open.aragonpm.eth",
-      "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
-      "network": "rinkeby"
-    },
     "staging": {
       "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
       "appName": "token-request.open.aragonpm.eth",
       "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
       "network": "rinkeby"
     },
+    "rinkeby": {
+      "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
+      "appName": "token-request.aragonpm.eth",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
+      "network": "rinkeby"
+    },
     "mainnet": {
       "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
-      "appName": "token-request.open.aragonpm.eth",
+      "appName": "token-request.aragonpm.eth",
       "wsRPC": "wss://mainnet.eth.aragon.network/ws",
       "network": "mainnet"
     }


### PR DESCRIPTION
Removes `.open` from app name
Also reordered networks